### PR TITLE
chore: set gitBaseBranchName to master in deployment.yaml

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -18,6 +18,7 @@
       - name: node-ci-v2
         parameters:
           sonarProjectName: cli-plugin-support
+          gitBaseBranchName: "master"
           nodeVersion: 20-bookworm
           nodeCommands:
             - test -- --passWithNoTests --coverage


### PR DESCRIPTION
## Summary
- Add `gitBaseBranchName: "master"` to the `node-ci-v2` pipeline in `.vtex/deployment.yaml`
- Ensures SonarQube uses `master` as the base branch for new code analysis

## Test plan
- [ ] CI pipeline runs successfully on this PR
